### PR TITLE
Add offline response

### DIFF
--- a/receiveMessages.gs
+++ b/receiveMessages.gs
@@ -82,7 +82,7 @@ function myFunction() {
     }
     currColumn++;
     if (isAfterHours) {
-      sheet.getRange(currRow, currColumn).setValue("Twin Cities Mutual Aid: Thanks for your message. We are currently offline. We'll get back to you by 8am CT");
+      sheet.getRange(currRow, currColumn).setValue("Twin Cities Mutual Aid: Thanks for your message. We are currently offline. We'll get back to you starting at 8am CT");
       currColumn++;
       sheet.getRange(currRow, currColumn).setValue("READY");
     }

--- a/receiveMessages.gs
+++ b/receiveMessages.gs
@@ -1,8 +1,9 @@
-function getMediaAssets(messageSid, accountSid, options) { 
-  const reqUrl = "https://api.twilio.com/2010-04-01/Accounts/" + accountSid + "/Messages/" + messageSid + "/Media.json";
-  const response = UrlFetchApp.fetch(reqUrl,options);
+function getMediaAssets(messageSid, accountSid, options) {
+  const reqUrl =
+    "https://api.twilio.com/2010-04-01/Accounts/" + accountSid + "/Messages/" + messageSid + "/Media.json";
+  const response = UrlFetchApp.fetch(reqUrl, options);
   const assets = JSON.parse(response.getContentText()).media_list;
-  
+
   var mediaLinks = [];
   for (var k = 0; k < assets.length; k++) {
     mediaLinks.push("https://api.twilio.com" + assets[k].uri.slice(0, assets[k].uri.length - 5));
@@ -18,16 +19,22 @@ function myFunction() {
   const hoursOffset = 0;
 
   var options = {
-    "method" : "get"
+    "method": "get",
   };
   options.headers = {
-    "Authorization" : "Basic " + Utilities.base64Encode(ACCOUNT_SID + ":" + ACCOUNT_TOKEN)
+    "Authorization": "Basic " + Utilities.base64Encode(ACCOUNT_SID + ":" + ACCOUNT_TOKEN),
   };
-  var url="https://api.twilio.com/2010-04-01/Accounts/" + ACCOUNT_SID + "/Messages.json?To=" + toPhoneNumber + "&PageSize=" + numberToRetrieve;
-  var response = UrlFetchApp.fetch(url,options);
+  var url =
+    "https://api.twilio.com/2010-04-01/Accounts/" +
+    ACCOUNT_SID +
+    "/Messages.json?To=" +
+    toPhoneNumber +
+    "&PageSize=" +
+    numberToRetrieve;
+  var response = UrlFetchApp.fetch(url, options);
 
   // Parse any new JSON data and put it into the correct sheet page.
-  var sheet = SpreadsheetApp.getActive().getSheetByName('Receive');
+  var sheet = SpreadsheetApp.getActive().getSheetByName("Receive");
   // Find the first empty row / find the number of messages already added to the sheet
   var numEntries = sheet.getRange("C2:C").getValues().filter(Number).length;
   Logger.log(numEntries);
@@ -35,23 +42,29 @@ function myFunction() {
   var startColumn = 1;
   var messageTextColumn = 5;
   var dataAll = JSON.parse(response.getContentText());
-  
+
   // (length - numEntries - 1) to ignore the text messages that have already been added to the sheet
   for (var i = dataAll.messages.length - numEntries - 1; i >= 0; i--) {
     var currColumn = startColumn;
     // populate date and time columns
-    rowDate = dataAll.messages[i].date_sent;
-    var currDate = new Date (rowDate);
-    if(isNaN(currDate.valueOf())) {
-      currDate = 'Not a valid date-time';
+    var rowDate = dataAll.messages[i].date_sent;
+    var currDateTime = new Date(rowDate);
+    var isAfterHours = false;
+    if (isNaN(currDateTime.valueOf())) {
+      currDateTime = "Not a valid date-time";
       currColumn++;
       currColumn++;
-    }
-    else {
-      currDate.setHours(currDate.getHours()+hoursOffset);
+    } else {
+      currDateTime = Utilities.formatDate(currDateTime, "America/Chicago", "yyyy-MM-dd HH:mm");
+      var currDate = currDateTime.split(" ")[0];
+      var currTime = currDateTime.split(" ")[1];
+      var currHour = Number(currTime.split(":")[0]);
+      if (currHour > 23 || currHour < 8) {
+        isAfterHours = true;
+      }
       sheet.getRange(currRow, currColumn).setValue(currDate);
       currColumn++;
-      sheet.getRange(currRow, currColumn).setValue(currDate);
+      sheet.getRange(currRow, currColumn).setValue(currTime);
       currColumn++;
     }
     // populate phone numbers + message body columns
@@ -63,12 +76,15 @@ function myFunction() {
     currColumn++;
     // populate image links column if media assets exist
     if (dataAll.messages[i].num_media > 0) {
-      Logger.log("message with media assets: \n\n")
-      Logger.log(dataAll.messages[i])
       var mediaLinks = getMediaAssets(dataAll.messages[i].sid, ACCOUNT_SID, options);
       mediaLinks = mediaLinks.join(", ");
       sheet.getRange(currRow, currColumn).setValue(mediaLinks);
+    }
+    currColumn++;
+    if (isAfterHours) {
+      sheet.getRange(currRow, currColumn).setValue("Twin Cities Mutual Aid: Thanks for your message. We are currently offline. We'll get back to you by 8am CT");
       currColumn++;
+      sheet.getRange(currRow, currColumn).setValue("READY");
     }
     currRow++;
   }


### PR DESCRIPTION
I thought it would make more sense to keep as much of the Twilio functionality as possible in the Google Script so that everyone has access to it / knows where to look. So instead of configuring the offline auto-responses in Twilio, I configured them in the script using the same response flow as we are currently using for messages.

If a message is received between 11pm and 8am, the "Response" column will be auto-populated with the following message: 
> Twin Cities Mutual Aid: Thanks for your message. We are currently offline. We'll get back to you starting at 8am CT

Then when the sendResponses script runs, it will automatically send that response.

One other related question: I currently have an auto-response for all messages at all times (configured in Twilio) that is sent immediately after a user sends a text:
> Twin Cities Mutual Aid: Thanks for your message. We will update resources ASAP. https://twin-cities-mutual-aid.org/

Since a custom response could take several minutes to reach the person who sent in the information, I think it's valuable to have an immediate auto-response that acknowledges we received the message, but I can edit the wording or disable this response entirely if it might be too much noise. 